### PR TITLE
开发环境下动态导入UMD模块导致Error

### DIFF
--- a/src/site-config/config.js
+++ b/src/site-config/config.js
@@ -36,6 +36,7 @@ export const baseConfig = {
     },
     plugins: [blogArchivePlugin()],
     optimizeDeps: {
+      include: [`${PackageJson.name} > valine`],
       /**
        * 开发模式下，Symbol变量被提取进入单独模块，导致存在两个同名的Symbol变量
        * 详情：https://github.com/vuejs/vitepress/issues/3292


### PR DESCRIPTION
本地``测试项目1``环境：
``node`` v18.19.0
``vitepress`` v1.0.0-rc.31
``vite`` v5.0.5
``vitepress-pure-theme-zyco`` 通过link链接本地包

```ts
// vitepress-pure-theme-zyco的useValine中动态导入UMD模块valine
import("valine").then(({ default: Valine }) => {
  ......
}
```
在测试项目1中生产和开发环境皆正常。

本地``测试项目2``环境：
``node`` v18.19.0
``vitepress`` v1.4.1
``vite`` v5.4.9
``vitepress-pure-theme-zyco`` v0.3.0

生产环境正常，开发环境出现error
<img width="490" src="https://github.com/user-attachments/assets/840a89b6-73f2-46e6-b16f-3417bc6505eb">

#### 报错原因

动态``import``引入UMD模块，在动态引入模块的上下文环境下，``window``是undefined，因此UMD模块挂载库代码到window上时出现error

#### 两个项目一个报错，一个正常，出现差异的原因

一开始以为是不同版本的vite导致的开发环境的差异，分析了vite的打包源码后，两版本vite无论开发模式还是生产模式下的打包，都会通过``@rollup/plugin-commonjs``将模块转化为``ESM``，因此并非vite版本差异导致问题

最后发现是link本地vitepress-pure-theme-zyco，导致vite在开发环境下，进行optimize deps(依赖优化)时，valine会被处理，而通过安装依赖vitepress-pure-theme-zyco，optimize deps会跳过valine

```js
// vite v5.4.9
// 在vite插件import-analysis进行依赖分析后，通过插件vite:resolve解析包信息的时候，利用tryNodeResolve方法解析valine
function tryNodeResolve( ){
  ...
  // 这里skipOptimization决定了是否对模块进行依赖优化，即转化为ES模块
  const skipOptimization = !options.ssrOptimizeCheck && depsOptimizer?.options.noDiscovery || !isJsType || importer && 
  isInNodeModules$1(importer) || exclude?.includes(pkgId) || exclude?.includes(id) || SPECIAL_QUERY_RE.test(resolved) || 
    !options.ssrOptimizeCheck && !isBuild && ssr || ssr && isFilePathESM(resolved, options.packageCache) && ! 
  (include?.includes(pkgId) || include?.includes(id));
  ...
  if (skipOptimization) {
    // 跳过了依赖优化
  } else {
    // 这里的逻辑决定该包会被optimize deps
    const optimizedInfo = depsOptimizer.registerMissingImport(id, resolved);
    resolved = depsOptimizer.getOptimizedDepId(optimizedInfo);
  }
}
```
上面代码中``importer && isInNodeModules$1(importer)``决定``skipOptimization``true还是false至关重要

``开发环境下``，当link本地vitepress-pure-theme-zyco，然后vitepress-pure-theme-zyco的逻辑中动态引入了UMD模块valine，此时vite dev打包逻辑中importer是指向本地文件的一个绝对路径，``isInNodeModules$1``判断importer不是node_modules里的模块所以``importer && isInNodeModules$1(importer)``是false，最终``skipOptimization``为false，于是会对valine进行依赖优化

这也是为什么在``测试项目1``的开发环境下没有报错。

``开发环境下``，安装依赖vitepress-pure-theme-zyco，包逻辑中动态引入了UMD模块valine，此时vite dev打包逻辑中importer是指向node_modules的一个绝对路径，``isInNodeModules$1``判断importer是node_modules里的模块文件，所以``importer && isInNodeModules$1(importer)``是true，最终``skipOptimization``为true，于是依赖优化会跳过valine

这也是为什么在``测试项目2``的开发环境下会出现Error，即``依赖的依赖``会被跳过。



